### PR TITLE
[+] Allow more icon options for website links using iconify

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@iconify-json/ep": "^1.1.8",
     "@iconify-json/fa6-solid": "^1.1.10",
+    "@iconify/vue": "^4.1.1",
     "@types/fs-extra": "^11.0.0",
     "@types/gtag.js": "^0.0.12",
     "@types/marked": "^4.0.8",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -10,6 +10,7 @@ declare module 'vue' {
     BackupButtons: typeof import('./components/BackupButtons.vue')['default']
     ChannelBackupButton: typeof import('./components/ChannelBackupButton.vue')['default']
     Divider: typeof import('./components/divider.vue')['default']
+    DynamicIcon: typeof import('./components/DynamicIcon.vue')['default']
     ElTooltip: typeof import('element-plus/es')['ElTooltip']
     HyInput: typeof import('./components/HyInput.vue')['default']
     IEpCheck: typeof import('~icons/ep/check')['default']

--- a/src/components/DynamicIcon.vue
+++ b/src/components/DynamicIcon.vue
@@ -1,0 +1,29 @@
+<template>
+    <i v-if="getIcon(icon)" :class="getIcon(icon)"></i>
+    <Icon v-else-if="getIconifyIcon(icon)" :icon="getIconifyIcon(icon)" />
+    <IFasLink v-else />
+</template>
+
+<script lang="ts">
+import { Options, Vue } from 'vue-class-component';
+import {Prop} from "vue-property-decorator";
+import {fab} from "@/logic/constants";
+import {Icon} from "@iconify/vue";
+
+@Options({ components: {Icon} })
+export default class DynamicIcon extends Vue {
+    @Prop() icon!: string
+
+    getIcon(platform: string): string | undefined
+    {
+        platform = platform.toLowerCase()
+        if (fab.includes(platform)) return `fab fa-${platform}`
+        if (platform.startsWith('custom-icon:')) return platform.replace('custom-icon:', '')
+    }
+
+    getIconifyIcon(icon: string): string | undefined
+    {
+        if (icon.startsWith('iconify:')) return icon.replace('iconify:', '')
+    }
+}
+</script>

--- a/src/components/MDX.vue
+++ b/src/components/MDX.vue
@@ -5,6 +5,7 @@ import { computed, defineComponent } from 'vue';
 import PhotoScroll from './PhotoScroll.vue';
 import ChannelBackupButton from "@/components/ChannelBackupButton.vue";
 import BackupButtons from "@/components/BackupButtons.vue";
+import DynamicIcon from "@/components/DynamicIcon.vue";
 
 export default defineComponent({
     name: "MDX",
@@ -34,7 +35,7 @@ export default defineComponent({
                 {
                     renderFunction.value?.({
                         components: {
-                            PhotoScroll, ChannelBackupButton, BackupButtons
+                            PhotoScroll, ChannelBackupButton, BackupButtons, DynamicIcon
                         }
                     })
                 }

--- a/src/components/ProfileCard.vue
+++ b/src/components/ProfileCard.vue
@@ -38,8 +38,7 @@
             <div id="websites" v-if="p.websites?.length">
                 <span id="websites-text">{{i18n.nav_website}}</span>
                 <a v-for="web of p.websites" :key="web[0]" :href="web[1]">
-                    <i v-if="getIcon(web[0])" :class="getIcon(web[0])"></i>
-                    <IFasLink v-else />
+                    <DynamicIcon :icon="web[0]" />
                 </a>
             </div>
         </div>
@@ -84,13 +83,6 @@ export default class ProfileCard extends Vue
                 info(`Flowers: ${it}`)
                 this.flowers = parseInt(it)
             })
-    }
-
-    getIcon(platform: string): string | undefined
-    {
-        platform = platform.toLowerCase()
-        if (fab.includes(platform)) return `fab fa-${platform}`
-        if (platform.startsWith('custom-icon:')) return platform.replace('custom-icon:', '')
     }
 
     flower(): void

--- a/src/components/ProfileCard.vue
+++ b/src/components/ProfileCard.vue
@@ -54,7 +54,6 @@ import {backendHost, replaceUrlVars} from "@/logic/config";
 import {abbreviateNumber, getTodayDate} from "@/logic/helper";
 import {Person} from "@/logic/data";
 import { info } from '@/logic/utils';
-import {fab} from "@/logic/constants";
 import Swal from 'sweetalert2';
 import {getLang, i18n} from '@/logic/config';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,6 +519,13 @@
     kolorist "^1.8.0"
     local-pkg "^0.4.3"
 
+"@iconify/vue@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@iconify/vue/-/vue-4.1.1.tgz#c143c2973a4990ba2b47b766f80a9bca97937305"
+  integrity sha512-RL85Bm/DAe8y6rT6pux7D2FJSiUEM/TPfyK7GrbAOfTSwrhvwJW+S5yijdGcmtXouA8MtuH9C7l4hiSE4mLMjg==
+  dependencies:
+    "@iconify/types" "^2.0.0"
+
 "@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"


### PR DESCRIPTION
After this change, it is possible to add any icon from Iconify, which includes a large collection of icons from many open-sourced icon libraries. https://icon-sets.iconify.design/

For example:

<img width="192" alt="image" src="https://github.com/one-among-us/web/assets/22280294/68160633-fc6a-44f0-87aa-af6acc2168af">

Will show up as:

<img width="140" alt="image" src="https://github.com/one-among-us/web/assets/22280294/695bea9d-1318-4620-bb6b-7cc7c5ed9095">
